### PR TITLE
小顶堆实现的 find_k_largest，提速 45.12%🚀

### DIFF
--- a/util/algorithm.py
+++ b/util/algorithm.py
@@ -1,6 +1,7 @@
 from numpy.linalg import norm
 from math import sqrt, exp
 from numba import jit
+import heapq
 
 
 def l1(x):
@@ -144,30 +145,15 @@ def denormalize(vec, max_val, min_val):
 def find_k_largest(K, candidates):
     n_candidates = []
     for iid, score in enumerate(candidates[:K]):
-        n_candidates.append((iid, score))
-    n_candidates.sort(key=lambda d: d[1], reverse=True)
-    k_largest_scores = [item[1] for item in n_candidates]
-    ids = [item[0] for item in n_candidates]
-    # find the K largest scores
+        n_candidates.append((score, iid))
+
+    heapq.heapify(n_candidates)
+
     for iid, score in enumerate(candidates[K:]):
-        ind = K
-        l = 0
-        r = K - 1
-        if k_largest_scores[r] < score:
-            while r >= l:
-                mid = int((r - l) / 2) + l
-                if k_largest_scores[mid] >= score:
-                    l = mid + 1
-                elif k_largest_scores[mid] < score:
-                    r = mid - 1
-                if r < l:
-                    ind = r
-                    break
-        # move the items backwards
-        if ind < K - 2:
-            k_largest_scores[ind + 2:] = k_largest_scores[ind + 1:-1]
-            ids[ind + 2:] = ids[ind + 1:-1]
-        if ind < K - 1:
-            k_largest_scores[ind + 1] = score
-            ids[ind + 1] = iid+K
+        if score > n_candidates[0][0]:
+            # 比堆顶元素大，入堆
+            heapq.heapreplace(n_candidates, (score, iid + K))
+    n_candidates.sort(key=lambda d: d[0], reverse=True)
+    ids = [item[1] for item in n_candidates]
+    k_largest_scores = [item[0] for item in n_candidates]
     return ids, k_largest_scores


### PR DESCRIPTION
前辈你好~ 最近我在基于 SELFRec 做一些实验，也是刚刚发现最新一次 [commit](https://github.com/Coder-Yu/SELFRec/commit/d168e595e73233bf03ade5f3365c2e538b0c5820) 修复了 top k 查询里的小 bug。

我这边用小顶堆写了一个优化版本的，时间大概能增速 45.12%（如下 benchmark，11.48s -> 6.30s），可以参考看合适的话更新到项目中。

辛苦~

```python
from numba import jit
import heapq


@jit(nopython=True)
def find_k_largest(K, candidates):
    n_candidates = []
    for iid, score in enumerate(candidates[:K]):
        n_candidates.append((iid, score))
    n_candidates.sort(key=lambda d: d[1], reverse=True)
    k_largest_scores = [item[1] for item in n_candidates]
    ids = [item[0] for item in n_candidates]
    # find the K largest scores
    for iid, score in enumerate(candidates[K:]):
        ind = K
        l = 0
        r = K - 1
        if k_largest_scores[r] < score:
            while r >= l:
                mid = int((r - l) / 2) + l
                if k_largest_scores[mid] >= score:
                    l = mid + 1
                elif k_largest_scores[mid] < score:
                    r = mid - 1
                if r < l:
                    ind = r
                    break
        # move the items backwards
        if ind < K - 2:
            k_largest_scores[ind + 2:] = k_largest_scores[ind + 1:-1]
            ids[ind + 2:] = ids[ind + 1:-1]
        if ind < K - 1:
            k_largest_scores[ind + 1] = score
            ids[ind + 1] = iid + K
    return ids, k_largest_scores


@jit(nopython=True)
def find_k_largest_v2(K, candidates):
    n_candidates = []
    for iid, score in enumerate(candidates[:K]):
        n_candidates.append((score, iid))

    heapq.heapify(n_candidates)

    for iid, score in enumerate(candidates[K:]):
        if score > n_candidates[0][0]:
            # 比堆顶元素大，入堆
            heapq.heapreplace(n_candidates, (score, iid + K))
    n_candidates.sort(key=lambda d: d[0], reverse=True)
    ids = [item[1] for item in n_candidates]
    k_largest_scores = [item[0] for item in n_candidates]
    return ids, k_largest_scores


if __name__ == '__main__':
    import numpy as np
    import time
    from tqdm import tqdm

    s1 = 0.0
    s2 = 0.0
    for i in tqdm(range(10000)):
        a = np.random.rand(1000000)
        k = 20
        start_time = time.time()
        ids, k_largest_scores = find_k_largest(k, a)
        s1 += time.time() - start_time

        start_time = time.time()
        ids2, k_largest_scores2 = find_k_largest_v2(k, a)
        s2 += time.time() - start_time

        if ids != ids2:
            print(ids)
            print(k_largest_scores)
            print(ids2)
            print(k_largest_scores2)
    print('s1: ', s1)
    print('s2: ', s2)
```

**Result:**
```
s1:  11.489959478378296
s2:  6.301436901092529
```
